### PR TITLE
add gulp-jshint as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "browserify": "~9.0.8",
     "gulp": "~3.9.0",
+    "gulp-jshint": "~1.11.0",
     "gulp-streamify": "~0.0.5",
     "gulp-uglify": "~1.2.0",
     "gulp-util": "~3.0.4",


### PR DESCRIPTION
Because the gulp file requires it: https://github.com/niklasf/chessground/blob/618e0c5db60267df/gulpfile.js#L4