### PR TITLE
Set board background interpolation mode to pixelate

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -37,6 +37,13 @@
   width: 100%;
   height: 100%;
 }
+.cg-board:not(.is3d) {
+  image-rendering: -moz-crisp-edges;
+  image-rendering: -o-crisp-edges;
+  image-rendering: -webkit-optimize-contrast;
+  image-rendering: pixelated;
+  -ms-interpolation-mode: nearest-neighbor;
+}
 square {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Right now, when scaling the background board image, most browsers will scale using an algorithm that was designed for photographs, which blurs edges to reduce artifacts, etc. For an image like the chessboard background, it results in a jarring combination of "soft" and "hard" edges, sometimes adjacent to each other, which makes the whole board feel sort of fuzzy.

Instead, it should use a nearest-neighbors algorithm that preserves hard pixel-color boundaries. The result is something like this: (for best comparison, open each image up in its own tab and very quickly toggle between them)

| Before  | After |
| ------------- | ------------- |
| ![](http://i.imgur.com/U4g2rmb.png)  | ![](http://i.imgur.com/X6n810c.png) |

In terms of browser support, I'm including the set of vendor prefixes [described here](https://developer.mozilla.org/en/docs/Web/CSS/image-rendering). (Note that they also use a chessboard image as the canonical example of when the `pixelated` filter is preferred!)

Note that this is related to #28 - this reduces (although does not completely eliminate) the effect described there.