### PR TITLE
make a named type for MaterialDiff.{white|black}

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -28,9 +28,12 @@ export type NumberPair = [number, number];
 export interface Dests {
   [key: string]: Key[]
 }
+export interface MaterialDiffSide {
+  [role: string]: number;
+}
 export interface MaterialDiff {
-  white: { [role: string]: number }
-  black: { [role: string]: number }
+  white: MaterialDiffSide;
+  black: MaterialDiffSide;
 }
 export interface Elements {
   board: HTMLElement;


### PR DESCRIPTION
In https://github.com/ornicar/lila/blob/93a2b0f0668e61e3d6fde2bc44f837a6417a1df8/ui/round/src/view/main.ts#L17 `materialDiff` is actually the white/black side of a `cg.MaterialDiff` (type error is right now hidden by implicit any). Adding a `MaterialDiffSide` type would be useful.