### PR TITLE
Revert "remove div.over element after ornicar/lila#4075"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ Chessground is designed to fulfill all lichess.org web and mobile apps needs, so
   - minimum distance before drag
   - centralisation of the piece under the cursor
   - piece ghost element
+  - square over elements
   - drop off revert or trash
 - Premove by click or drag
 - Drag new pieces onto the board (editor, crazyhouse)
 - Animation of pieces: moving and fading away
-- Display last move, check, move destinations, and premove destinations (hover effects possible)
+- Display last move, check, move destinations, and premove destinations
 - Import and export positions in FEN notation
 - User callbacks
 - No chess logic inside: can be used for [chess variants](https://lichess.org/variant)

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -13,6 +13,8 @@ export interface DragCurrent {
   epos: cg.NumberPair; // initial event position
   pos: cg.NumberPair; // relative current position
   dec: cg.NumberPair; // piece center decay
+  over?: cg.Key; // square being moused over
+  overPrev?: cg.Key; // square previously moused over
   started: boolean; // whether the drag has started; as per the distance setting
   element: cg.PieceNode | (() => cg.PieceNode | undefined);
   newPiece?: boolean; // it it a new piece from outside the board
@@ -142,12 +144,32 @@ function processDrag(s: State): void {
           cur.epos[0] - cur.rel[0],
           cur.epos[1] - cur.rel[1]
         ];
+        cur.over = board.getKeyAtDomPos(cur.epos, asWhite, bounds);
 
         // move piece
         const translation = util.posToTranslateAbs(bounds)(cur.origPos, asWhite);
         translation[0] += cur.pos[0] + cur.dec[0];
         translation[1] += cur.pos[1] + cur.dec[1];
         util.translateAbs(cur.element, translation);
+
+        // move over element
+        const overEl = s.dom.elements.over;
+        if (overEl && cur.over && cur.over !== cur.overPrev) {
+          const dests = s.movable.dests;
+          if (s.movable.free ||
+            util.containsX(dests && dests[cur.orig], cur.over) ||
+            util.containsX(s.premovable.dests, cur.over)) {
+            const pos = util.key2pos(cur.over),
+            vector: cg.NumberPair = [
+              (asWhite ? pos[0] - 1 : 8 - pos[0]) * bounds.width / 8,
+              (asWhite ? 8 - pos[1] : pos[1] - 1) * bounds.height / 8
+            ];
+            util.translateAbs(overEl, vector);
+          } else {
+            util.translateAway(overEl);
+          }
+          cur.overPrev = cur.over;
+        }
       }
     }
     processDrag(s);
@@ -210,6 +232,7 @@ export function cancel(s: State): void {
 
 function removeDragElements(s: State) {
   const e = s.dom.elements;
+  if (e.over) util.translateAway(e.over);
   if (e.ghost) util.translateAway(e.ghost);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface MaterialDiff {
 }
 export interface Elements {
   board: HTMLElement;
+  over?: HTMLElement;
   ghost?: HTMLElement;
   svg?: SVGElement;
 }

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -31,6 +31,15 @@ export default function wrap(element: HTMLElement, s: State, bounds?: ClientRect
     element.appendChild(renderCoords(files, 'files' + orientClass));
   }
 
+  let over: HTMLElement | undefined;
+  if (bounds && (s.movable.showDests || s.premovable.showDests)) {
+    over = createEl('div', 'over');
+    translateAway(over);
+    over.style.width = (bounds.width / 8) + 'px';
+    over.style.height = (bounds.height / 8) + 'px';
+    element.appendChild(over);
+  }
+
   let ghost: HTMLElement | undefined;
   if (bounds && s.draggable.showGhost) {
     ghost = createEl('piece', 'ghost');
@@ -40,6 +49,7 @@ export default function wrap(element: HTMLElement, s: State, bounds?: ClientRect
 
   return {
     board: board,
+    over: over,
     ghost: ghost,
     svg: svg
   };


### PR DESCRIPTION
This reverts commit d2b6b10f58f17e0c670417abe7814badf1c38bf8.

`div.over` is needed for crazyhouse drops.