### PR TITLE
Draw hotkey to keep premoves

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -62,7 +62,7 @@ export function start(state: State, e: cg.MouchEvent): void {
   if (e.touches && e.touches.length > 1) return; // support one finger touch only
   e.stopPropagation();
   e.preventDefault();
-  cancelMove(state);
+  if (!e.ctrlKey) cancelMove(state);
   const position = eventPosition(e) as cg.NumberPair;
   const orig = getKeyAtDomPos(position, state.orientation === 'white', state.dom.bounds());
   if (!orig) return;

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,5 +1,5 @@
 import { State } from './state'
-import { cancelMove, getKeyAtDomPos } from './board'
+import { unselect, cancelMove, getKeyAtDomPos } from './board'
 import { eventPosition, raf, isRightButton } from './util'
 import * as cg from './types'
 
@@ -62,7 +62,7 @@ export function start(state: State, e: cg.MouchEvent): void {
   if (e.touches && e.touches.length > 1) return; // support one finger touch only
   e.stopPropagation();
   e.preventDefault();
-  if (!e.ctrlKey) cancelMove(state);
+  e.ctrlKey ? unselect(state) : cancelMove(state);
   const position = eventPosition(e) as cg.NumberPair;
   const orig = getKeyAtDomPos(position, state.orientation === 'white', state.dom.bounds());
   if (!orig) return;


### PR DESCRIPTION
When drawing with an active premove, don't cancel if ctrl is held.