### PR TITLE
remove unused MaterialDiff type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,13 +30,7 @@ export type NumberQuad = [number, number, number, number];
 export interface Dests {
   [key: string]: Key[]
 }
-export interface MaterialDiffSide {
-  [role: string]: number;
-}
-export interface MaterialDiff {
-  white: MaterialDiffSide;
-  black: MaterialDiffSide;
-}
+
 export interface Elements {
   board: HTMLElement;
   ghost?: HTMLElement;


### PR DESCRIPTION
These should not be part of chessground. Will require some care when updating chessground for lila (which *does* use these).