### PR TITLE
add div.cg-board-helper

### DIFF
--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -23,9 +23,9 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
     element.classList.add('cg-board-wrap');
     // compute bounds from existing board element if possible
     // this allows non-square boards from CSS to be handled (for 3D)
-    const bounds = util.memo(() => element.getBoundingClientRect());
     const relative = state.viewOnly && !state.drawable.visible;
-    const elements = renderWrap(element, state, relative ? undefined : bounds());
+    const elements = renderWrap(element, state, relative);
+    const bounds = util.memo(() => elements.board.getBoundingClientRect());
     const redrawNow = (skipSvg?: boolean) => {
       render(state);
       if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg);

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -4,7 +4,16 @@ import { files, ranks } from './types'
 import { createElement as createSVG } from './svg'
 import { Elements } from './types'
 
-export default function wrap(element: HTMLElement, s: State, bounds?: ClientRect): Elements {
+export default function wrap(element: HTMLElement, s: State, relative: boolean): Elements {
+
+  // div.cg-board-wrap
+  //   div
+  //     div
+  //       div.cg-board
+  //       svg
+  //       coords.ranks
+  //       coords.files
+  //       piece.ghost
 
   element.innerHTML = '';
 
@@ -14,28 +23,32 @@ export default function wrap(element: HTMLElement, s: State, bounds?: ClientRect
   });
   element.classList.toggle('manipulable', !s.viewOnly);
 
-  const board = createEl('div', 'cg-board');
+  const helper = createEl('div');
+  element.appendChild(helper);
+  const container = createEl('div');
+  helper.appendChild(container);
 
-  element.appendChild(board);
+  const board = createEl('div', 'cg-board');
+  container.appendChild(board);
 
   let svg: SVGElement | undefined;
-  if (s.drawable.visible && bounds) {
+  if (s.drawable.visible && !relative) {
     svg = createSVG('svg');
     svg.appendChild(createSVG('defs'));
-    element.appendChild(svg);
+    container.appendChild(svg);
   }
 
   if (s.coordinates) {
     const orientClass = s.orientation === 'black' ? ' black' : '';
-    element.appendChild(renderCoords(ranks, 'ranks' + orientClass));
-    element.appendChild(renderCoords(files, 'files' + orientClass));
+    container.appendChild(renderCoords(ranks, 'ranks' + orientClass));
+    container.appendChild(renderCoords(files, 'files' + orientClass));
   }
 
   let ghost: HTMLElement | undefined;
-  if (bounds && s.draggable.showGhost) {
+  if (s.draggable.showGhost && !relative) {
     ghost = createEl('piece', 'ghost');
     setVisible(ghost, false);
-    element.appendChild(ghost);
+    container.appendChild(ghost);
   }
 
   return {


### PR DESCRIPTION
There is a hack to make board sizes divisible by 8 in Chrome: https://jsfiddle.net/9cgytwr5/1/

It works with absolute positioning of the pieces or by adding an additional wrapping div. This PR does the latter.

Sharp board and pieces and perfectly aligned square highlights confirmed by people in Discord (including City, who previously managed to break everything).

Combined with the following diff in lila:

```diff
diff --git a/app/templating/ChessgroundHelper.scala b/app/templating/ChessgroundHelper.scala
index e09e1c76f9..3885695085 100644
--- a/app/templating/ChessgroundHelper.scala
+++ b/app/templating/ChessgroundHelper.scala
@@ -39,7 +39,9 @@ trait ChessgroundHelper {
   )
 
   private def wrap(content: Frag): Frag = div(cls := "cg-board-wrap")(
-    div(cls := "cg-board")(content)
+    div(cls := "cg-board-helper")(
+      div(cls := "cg-board")(content)
+    )
   )
 
   lazy val miniBoardContent = wrap("")
diff --git a/ui/common/css/vendor/chessground/_chessground.scss b/ui/common/css/vendor/chessground/_chessground.scss
index 65fb2a7328..150649d26d 100644
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -1,7 +1,17 @@
 @import 'board-2d';
 
+.cg-board-helper {
+  position: absolute;
+  display: table; /* round to integer size in chrome */
+  width: 12.5%;
+  height: 12.5%;
+}
+
 .cg-board {
-  @extend %box-shadow, %abs-100;
+  @extend %box-shadow;
+  position: absolute;
+  width: 800%;
+  height: 800%;
   user-select: none;
   line-height: 0;
   background-size: cover;
@@ -58,6 +68,7 @@ piece {
   height: 12.5%;
   background-size: cover;
   z-index: z('cg__piece');
+  will-change: transform;
   pointer-events: none;
   &.dragging {
     cursor: move;
```