### PR TITLE
add two helper divs

### DIFF
--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -23,9 +23,9 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
     element.classList.add('cg-board-wrap');
     // compute bounds from existing board element if possible
     // this allows non-square boards from CSS to be handled (for 3D)
-    const bounds = util.memo(() => element.getBoundingClientRect());
     const relative = state.viewOnly && !state.drawable.visible;
-    const elements = renderWrap(element, state, relative ? undefined : bounds());
+    const elements = renderWrap(element, state, relative);
+    const bounds = util.memo(() => elements.board.getBoundingClientRect());
     const redrawNow = (skipSvg?: boolean) => {
       render(state);
       if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg);

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -4,7 +4,16 @@ import { files, ranks } from './types'
 import { createElement as createSVG } from './svg'
 import { Elements } from './types'
 
-export default function wrap(element: HTMLElement, s: State, bounds?: ClientRect): Elements {
+export default function wrap(element: HTMLElement, s: State, relative: boolean): Elements {
+
+  // div.cg-board-wrap
+  //   div
+  //     div
+  //       div.cg-board
+  //       svg
+  //       coords.ranks
+  //       coords.files
+  //       piece.ghost
 
   element.innerHTML = '';
 
@@ -14,28 +23,32 @@ export default function wrap(element: HTMLElement, s: State, bounds?: ClientRect
   });
   element.classList.toggle('manipulable', !s.viewOnly);
 
-  const board = createEl('div', 'cg-board');
+  const helper = createEl('div');
+  element.appendChild(helper);
+  const container = createEl('div');
+  helper.appendChild(container);
 
-  element.appendChild(board);
+  const board = createEl('div', 'cg-board');
+  container.appendChild(board);
 
   let svg: SVGElement | undefined;
-  if (s.drawable.visible && bounds) {
+  if (s.drawable.visible && !relative) {
     svg = createSVG('svg');
     svg.appendChild(createSVG('defs'));
-    element.appendChild(svg);
+    container.appendChild(svg);
   }
 
   if (s.coordinates) {
     const orientClass = s.orientation === 'black' ? ' black' : '';
-    element.appendChild(renderCoords(ranks, 'ranks' + orientClass));
-    element.appendChild(renderCoords(files, 'files' + orientClass));
+    container.appendChild(renderCoords(ranks, 'ranks' + orientClass));
+    container.appendChild(renderCoords(files, 'files' + orientClass));
   }
 
   let ghost: HTMLElement | undefined;
-  if (bounds && s.draggable.showGhost) {
+  if (s.draggable.showGhost && !relative) {
     ghost = createEl('piece', 'ghost');
     setVisible(ghost, false);
-    element.appendChild(ghost);
+    container.appendChild(ghost);
   }
 
   return {


### PR DESCRIPTION
There is a pure CSS hack to make board sizes divisible by 8 in Chrome. The easiest way to do it is with two extra helper divs.

Sharp boards and pieces and perfectly aligned square highlights confirmed by people in Discord, including City, who previously managed to break everything.

Works with board coordinates an 3D.

Accompanied by the following patch in lila (https://github.com/ornicar/lila/pull/5099):

```diff
--- a/ui/common/css/vendor/chessground/_chessground.scss
+++ b/ui/common/css/vendor/chessground/_chessground.scss
@@ -76,6 +76,19 @@ piece {
 }
 
 .cg-board-wrap {
+  > div {
+    position: absolute;
+    width: 12.5%;
+    height: 12.5%;
+    display: table; /* hack: round to full pixel size in chrome */
+    > div {
+      position: absolute;
+      width: 800%;
+      height: 800%;
+      display: block;
+    }
+  }
+
   // overflow: hidden; /* prevents width issues with rank coords | but prevents dragging pieces in! */
   svg {
     overflow: hidden;
```