### PR TITLE
Unfocus chat when clicking on board.

### DIFF
--- a/src/drag.ts
+++ b/src/drag.ts
@@ -36,7 +36,9 @@ export function start(s: State, e: cg.MouchEvent): void {
   if (!previouslySelected && s.drawable.enabled && (
     s.drawable.eraseOnClick || (!piece || piece.color !== s.turnColor)
   )) drawClear(s);
-  if (!e.touches || piece || previouslySelected || pieceCloseTo(s, position)) e.preventDefault();
+  if (e.type === 'touchstart' &&
+      (!e.touches || piece || previouslySelected || pieceCloseTo(s, position)))
+       e.preventDefault();
   const hadPremove = !!s.premovable.current;
   const hadPredrop = !!s.predroppable.current;
   s.stats.ctrlKey = e.ctrlKey;

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -60,8 +60,10 @@ const brushes = ['green', 'red', 'blue', 'yellow'];
 
 export function start(state: State, e: cg.MouchEvent): void {
   if (e.touches && e.touches.length > 1) return; // support one finger touch only
-  e.stopPropagation();
-  e.preventDefault();
+  if (e.type === 'touchstart') {
+    e.stopPropagation();
+    e.preventDefault();
+  }
   e.ctrlKey ? unselect(state) : cancelMove(state);
   const position = eventPosition(e) as cg.NumberPair;
   const orig = getKeyAtDomPos(position, state.orientation === 'white', state.dom.bounds());

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,10 +14,10 @@ export function bindBoard(s: State): void {
   const boardEl = s.dom.elements.board,
   onStart = startDragOrDraw(s);
 
-  // must NOT be a passive event!
 
-  boardEl.addEventListener('touchstart', onStart as EventListener);
-  boardEl.addEventListener('mousedown', onStart as EventListener);
+  // touchstart can't be passive because we disable scroll.
+  boardEl.addEventListener('touchstart', onStart as EventListener, { passive: false });
+  boardEl.addEventListener('mousedown', onStart as EventListener, { passive: true });
 
   if (s.disableContextMenu || s.drawable.enabled) {
     boardEl.addEventListener('contextmenu', e => e.preventDefault());


### PR DESCRIPTION
Fix chat focusing bug by adjusting mousedown
listener.  

Don't block mousedown events with preventDefault.
Consequently this can now be a passive listener.

Use `{passive: false}` for touchstart listener to:
- silence warning in console
- futureproof the listener in case passive changes to
  true by default.