### PR TITLE
support mixed touch/mouse devices (fixes ornicar/lila#5167)

### DIFF
--- a/src/drag.ts
+++ b/src/drag.ts
@@ -24,8 +24,6 @@ export interface DragCurrent {
 export function start(s: State, e: cg.MouchEvent): void {
   if (e.button !== undefined && e.button !== 0) return; // only touch or left click
   if (e.touches && e.touches.length > 1) return; // support one finger touch only
-  if (e.type === 'touchstart') s.stats.touched = true;
-  else if (e.type === 'mousedown' && s.stats.touched) return;
   const asWhite = s.orientation === 'white',
   bounds = s.dom.bounds(),
   position = util.eventPosition(e) as cg.NumberPair,
@@ -36,8 +34,12 @@ export function start(s: State, e: cg.MouchEvent): void {
   if (!previouslySelected && s.drawable.enabled && (
     s.drawable.eraseOnClick || (!piece || piece.color !== s.turnColor)
   )) drawClear(s);
-  if (e.type === 'touchstart' &&
-      (!e.touches || piece || previouslySelected || pieceCloseTo(s, position)))
+  // Prevent touch scroll and create no corresponding mouse event, if there
+  // is an intent to interact with the board. If no color is movable
+  // (and the board is not for viewing only), touches are likely intended to
+  // select squares.
+  if (e.type === 'touchstart' && e.cancelable !== false &&
+      (!e.touches || !s.movable.color || piece || previouslySelected || pieceCloseTo(s, position)))
        e.preventDefault();
   const hadPremove = !!s.premovable.current;
   const hadPredrop = !!s.predroppable.current;
@@ -184,6 +186,8 @@ export function move(s: State, e: cg.MouchEvent): void {
 export function end(s: State, e: cg.MouchEvent): void {
   const cur = s.draggable.current;
   if (!cur) return;
+  // create no corresponding mouse event
+  if (e.type === 'touchend' && e.cancelable !== false) e.preventDefault();
   // comparing with the origin target is an easy way to test that the end event
   // has the same touch origin
   if (e.type === 'touchend' && cur && cur.originTarget !== e.target && !cur.newPiece) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -82,7 +82,6 @@ export interface State {
     // was last piece dragged or clicked?
     // needs default to false for touch
     dragged: boolean,
-    touched: boolean, // has the screen been touched yet?
     ctrlKey?: boolean
   };
   events: {
@@ -154,8 +153,7 @@ export function defaults(): Partial<State> {
     stats: {
       // on touchscreen, default to "tap-tap" moves
       // instead of drag
-      dragged: !('ontouchstart' in window),
-      touched: false
+      dragged: !('ontouchstart' in window)
     },
     events: {},
     drawable: {


### PR DESCRIPTION
Explanation of how to prevent duplicate touch/mouse events:
https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent

Coordinate trainer: Covered by !s.movable.color

Board editor: Needs a seperate patch, because it has its own event
handling (ornicar/lila@f1bb1b22723c76753fa9d426b2f18843f2546ddb).

Reverts 04c68e18444754890b3223.