### PR TITLE
Hide dist js files in git diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/*.js -diff


### PR DESCRIPTION
When running `git diff`, instead of long diffs
of dist, show 'Binary files differ'.