### PR TITLE
Better typescript sourcemaps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
     "alwaysStrict": true,
     "target": "ES6",
     "module": "commonjs",
+    "inlineSourceMap": true,
+    "inlineSources": true,
     "lib": ["DOM", "ES6"]
   }
 }


### PR DESCRIPTION
Adjust tsconfig so that libraries that use chessground
will sourcemap back to original typescript files!