### PR TITLE
simplify away centerPiece, fix drag while scroll (ornicar/lila#5661)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,6 @@ export interface Config {
     enabled?: boolean; // allow moves & premoves to use drag'n drop
     distance?: number; // minimum distance to initiate a drag; in pixels
     autoDistance?: boolean; // lets chessground set distance to zero when user drags pieces
-    centerPiece?: boolean; // center the piece on cursor at drag start
     showGhost?: boolean; // show ghost of piece being dragged
     deleteOnDropOff?: boolean; // delete a piece when it is dropped off the board
   };

--- a/src/state.ts
+++ b/src/state.ts
@@ -65,7 +65,6 @@ export interface State {
     enabled: boolean; // allow moves & premoves to use drag'n drop
     distance: number; // minimum distance to initiate a drag; in pixels
     autoDistance: boolean; // lets chessground set distance to zero when user drags pieces
-    centerPiece: boolean; // center the piece on cursor at drag start
     showGhost: boolean; // show ghost of piece being dragged
     deleteOnDropOff: boolean; // delete a piece when it is dropped off the board
     current?: DragCurrent;
@@ -140,7 +139,6 @@ export function defaults(): Partial<State> {
       enabled: true,
       distance: 3,
       autoDistance: true,
-      centerPiece: true,
       showGhost: true,
       deleteOnDropOff: false
     },


### PR DESCRIPTION
`centerPiece: false` is unused in lila and unnecessarily complicates dragging logic. For example it did not correctly deal with scrolling while dragging (ornicar/lila#5661). The lichobile implementation of `centerPiece` has diverged anyway, so I see no reason to keep it around.