### PR TITLE
implement resize observer (closes #137)

### DIFF
--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -4,7 +4,7 @@ import { State, defaults } from './state'
 
 import renderWrap from './wrap';
 import * as events from './events'
-import render from './render';
+import { render, updateBounds } from './render';
 import * as svg from './svg';
 import * as util from './util';
 
@@ -24,6 +24,11 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
     redrawNow = (skipSvg?: boolean): void => {
       render(state);
       if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg);
+    },
+    boundsUpdated = (): void => {
+      bounds.clear();
+      updateBounds(state);
+      if (elements.svg) svg.renderSvg(state, elements.svg);
     };
     state.dom = {
       elements,
@@ -35,8 +40,8 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
     };
     state.drawable.prevSvgHash = '';
     redrawNow(false);
-    events.bindBoard(state);
-    if (!prevUnbind) state.dom.unbind = events.bindDocument(state, redrawAll);
+    events.bindBoard(state, boundsUpdated);
+    if (!prevUnbind) state.dom.unbind = events.bindDocument(state, boundsUpdated);
     state.events.insert && state.events.insert(elements);
   }
   redrawAll();

--- a/src/render.ts
+++ b/src/render.ts
@@ -17,7 +17,7 @@ interface SquareClasses { [key: string]: string }
 
 // ported from https://github.com/veloce/lichobile/blob/master/src/js/chessground/view.js
 // in case of bugs, blame @veloce
-export default function render(s: State): void {
+export function render(s: State): void {
   const asWhite: boolean = whitePov(s),
   posToTranslate = s.dom.relative ? util.posToTranslateRel : util.posToTranslateAbs(s.dom.bounds()),
   translate = s.dom.relative ? util.translateRel : util.translateAbs,
@@ -184,6 +184,19 @@ export default function render(s: State): void {
   // remove any element that remains in the moved sets
   for (const i in movedPieces) removeNodes(s, movedPieces[i]!);
   for (const i in movedSquares) removeNodes(s, movedSquares[i]!);
+}
+
+export function updateBounds(s: State) {
+  if (s.dom.relative) return;
+  const asWhite: boolean = whitePov(s),
+  posToTranslate = util.posToTranslateAbs(s.dom.bounds());
+  let el = s.dom.elements.board.firstChild as cg.PieceNode | cg.SquareNode | undefined;
+  while (el) {
+    if ((isPieceNode(el) && !el.cgAnimating) || isSquareNode(el)) {
+      util.translateAbs(el, posToTranslate(key2pos(el.cgKey), asWhite));
+    }
+    el = el.nextSibling as cg.PieceNode | cg.SquareNode | undefined;
+  }
 }
 
 function isPieceNode(el: cg.PieceNode | cg.SquareNode): el is cg.PieceNode {

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -28,7 +28,8 @@ export function renderSvg(state: State, root: SVGElement): void {
   const d = state.drawable,
   curD = d.current,
   cur = curD && curD.mouseSq ? curD as DrawShape : undefined,
-  arrowDests: ArrowDests = {};
+  arrowDests: ArrowDests = {},
+  bounds = state.dom.bounds();
 
   for (const s of d.shapes.concat(d.autoShapes).concat(cur ? [cur] : [])) {
     if (s.dest) arrowDests[s.dest] = (arrowDests[s.dest] || 0) + 1;
@@ -38,13 +39,13 @@ export function renderSvg(state: State, root: SVGElement): void {
     return {
       shape: s,
       current: false,
-      hash: shapeHash(s, arrowDests, false)
+      hash: shapeHash(s, arrowDests, false, bounds)
     };
   });
   if (cur) shapes.push({
     shape: cur,
     current: true,
-    hash: shapeHash(cur, arrowDests, true)
+    hash: shapeHash(cur, arrowDests, true, bounds)
   });
 
   const fullHash = shapes.map(sc => sc.hash).join('');
@@ -102,15 +103,15 @@ function syncShapes(state: State, shapes: Shape[], brushes: DrawBrushes, arrowDe
   }
 }
 
-function shapeHash({orig, dest, brush, piece, modifiers}: DrawShape, arrowDests: ArrowDests, current: boolean): Hash {
-  return [current, orig, dest, brush, dest && arrowDests[dest] > 1,
+function shapeHash({orig, dest, brush, piece, modifiers}: DrawShape, arrowDests: ArrowDests, current: boolean, bounds: ClientRect): Hash {
+  return [bounds.width, bounds.height, current, orig, dest, brush, dest && arrowDests[dest] > 1,
     piece && pieceHash(piece),
     modifiers && modifiersHash(modifiers)
-  ].filter(x => x).join('');
+  ].filter(x => x).join(',');
 }
 
 function pieceHash(piece: DrawShapePiece): Hash {
-  return [piece.color, piece.role, piece.scale].filter(x => x).join('');
+  return [piece.color, piece.role, piece.scale].filter(x => x).join(',');
 }
 
 function modifiersHash(m: DrawModifiers): Hash {


### PR DESCRIPTION
More robustness for bounds changes. Presumably fixes glitches like https://github.com/ornicar/lila/issues/5126.

Uses a new routine for updating bounds instead of triggering a full redraw, because the resize observer would trigger when the board element is replaced during redraw.

Unfortunately still requires the `chessground.resize` crutch for Edge < 79 and Safari < 13.1 (https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#Browser_compatibility).