### PR TITLE
Fix drawing inconsistency

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -76,7 +76,7 @@ function startDragOrDraw(s: State): MouchBind {
 
 function dragOrDraw(s: State, withDrag: StateMouchBind, withDraw: StateMouchBind): MouchBind {
   return e => {
-    if (e.shiftKey || isRightButton(e)) { if (s.drawable.enabled) withDraw(s, e); }
+    if (s.drawable.current) { if (s.drawable.enabled) withDraw(s, e); }
     else if (!s.viewOnly) withDrag(s, e);
   };
 }


### PR DESCRIPTION
Keep drawing as long as there is a DrawCurrent. This means drawing with left mouse button + shift will no longer fail to call `draw.move` and `draw.end` if shift is released before the mouse button. So now you can't enter an invalid state anymore where there is a DrawCurrent but no mouse button is pressed.

Fixes #140 