### PR TITLE
Free arrow by dragging mouse off board

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Chessground is designed to fulfill all lichess.org web and mobile apps needs, so
 - Fast. Uses a custom DOM diff algorithm to reduce DOM writes to the absolute minimum.
 - Small footprint: 10K gzipped (30K unzipped). No dependencies.
 - SVG drawing of circles and arrows on the board
-- Arrows snap to valid moves until dragging the mouse off the board and back while drawing an arrow
+- Arrows snap to valid moves. Freehand arrows can be drawn by dragging the mouse off the board and back while drawing an arrow.
 - Entirely configurable and reconfigurable at any time
 - Styling with CSS only: board and pieces can be changed by simply switching a class
 - Fluid layout: board can be resized at any time

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Chessground is designed to fulfill all lichess.org web and mobile apps needs, so
 - Fast. Uses a custom DOM diff algorithm to reduce DOM writes to the absolute minimum.
 - Small footprint: 10K gzipped (30K unzipped). No dependencies.
 - SVG drawing of circles and arrows on the board
-- optional arrow snapping to valid moves
+- Arrows snap to valid moves until dragging the mouse off the board and back while drawing an arrow
 - Entirely configurable and reconfigurable at any time
 - Styling with CSS only: board and pieces can be changed by simply switching a class
 - Fluid layout: board can be resized at any time

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -83,9 +83,13 @@ export function processDraw(state: State): void {
   requestAnimationFrame(() => {
     const cur = state.drawable.current;
     if (cur) {
+      const keyAtDomPos = getKeyAtDomPos(cur.pos, whitePov(state), state.dom.bounds());
+      if (!keyAtDomPos || !cur.snapToValidMove) {
+        cur.snapToValidMove = false;
+      }
       const mouseSq = cur.snapToValidMove ?
           getSnappedKeyAtDomPos(cur.orig, cur.pos, whitePov(state), state.dom.bounds()) :
-          getKeyAtDomPos(cur.pos, whitePov(state), state.dom.bounds());
+          keyAtDomPos;
       if (mouseSq !== cur.mouseSq) {
         cur.mouseSq = mouseSq;
         cur.dest = mouseSq !== cur.orig ? mouseSq : undefined;

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -84,7 +84,7 @@ export function processDraw(state: State): void {
     const cur = state.drawable.current;
     if (cur) {
       const keyAtDomPos = getKeyAtDomPos(cur.pos, whitePov(state), state.dom.bounds());
-      if (!keyAtDomPos || !cur.snapToValidMove) {
+      if (!keyAtDomPos) {
         cur.snapToValidMove = false;
       }
       const mouseSq = cur.snapToValidMove ?

--- a/src/events.ts
+++ b/src/events.ts
@@ -52,11 +52,6 @@ export function bindDocument(s: State, boundsUpdated: () => void): cg.Unbind {
     const onScroll = () => s.dom.bounds.clear();
     unbinds.push(unbindable(document, 'scroll', onScroll, { capture: true, passive: true }));
     unbinds.push(unbindable(window, 'resize', onScroll, { passive: true }));
-
-    if (s.drawable.enabled) {
-      unbinds.push(unbindable(document, 'keydown', toggleDrawSnap(s, true) as EventListener, { passive: false, capture: true }));
-      unbinds.push(unbindable(document, 'keyup', toggleDrawSnap(s, false) as EventListener, { passive: false, capture: true }));
-    }
   }
 
   return () => unbinds.forEach(f => f());
@@ -84,14 +79,4 @@ function dragOrDraw(s: State, withDrag: StateMouchBind, withDraw: StateMouchBind
     if (s.drawable.current) { if (s.drawable.enabled) withDraw(s, e); }
     else if (!s.viewOnly) withDrag(s, e);
   };
-}
-
-function toggleDrawSnap(s: State, toggle: boolean) {
-  return (e: KeyboardEvent) => {
-    if (e.key === 's' && s.drawable.current) {
-      e.stopPropagation();
-      e.preventDefault();
-      s.drawable.current.snapToValidMove = s.drawable.defaultSnapToValidMove !== toggle;
-    }
-  }
 }


### PR DESCRIPTION
Previously, holding `s` would temporarily toggle arrow snapping, but it was causing the search box to open in lila after releasing the mouse button.

Now, freehand arrows are performed by dragging the arrow off the board and back on.

Alternative solution: if s was pressed and not released while an arrow was being drawn, add an extra key event listener that captures all s key presses until s is released