### PR TITLE
Include CSS files on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "/*.js",
     "/*.d.ts",
     "/*.js.map",
+    "/assets/*.css",
     "/src/*.ts",
     "!/rollup.config.js"
   ],


### PR DESCRIPTION
#160/#134 adds CSS files for quicker setup but they are not getting installed when you `npm install`

This adds them to the `files[]` in `package.json` so that they get included.