### PR TITLE
Restore CSS rule for arrows

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -98,6 +98,18 @@ piece.fading {
   opacity: 0.5;
 }
 
+.cg-wrap svg {
+  overflow: hidden;
+  position: relative;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0.6;
+}
+
 .cg-wrap coords {
   position: absolute;
   display: flex;


### PR DESCRIPTION
Currently, when you right-click to draw an arrow, the `<svg>` element is present in the DOM but not visible on screen because of no CSS.

The new CSS assets are missing a rule for arrows. This PR restores the code from the previous [Chessground example CSS](https://github.com/ornicar/chessground-examples/blob/master/assets/chessground.css#L113-L123) linked from the readme.