### PR TITLE
Implement DrawShape.customSvg

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -98,7 +98,8 @@ piece.fading {
   opacity: 0.5;
 }
 
-.cg-wrap svg {
+/* NOTE: Only direct descendent so that it won't affect nested svg from DrawShape.customSvg */
+cg-container > svg {
   overflow: hidden;
   position: relative;
   top: 0px;

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -9,6 +9,7 @@ export interface DrawShape {
   brush: string;
   modifiers?: DrawModifiers;
   piece?: DrawShapePiece;
+  customSvg?: string;
 }
 
 export interface DrawShapePiece {


### PR DESCRIPTION
As a way to support this feature https://github.com/ornicar/chessground/issues/165, I implemented `DrawShape.customSvg`.
This looks a bit hack-ish, but for a moderate usage in analysis board, I thought this would be okay.
I also made an example on the example repository https://github.com/ornicar/chessground-examples/compare/master...hi-ogawa:custom-drawable.
Here is the screenshot:

![Screenshot from 2021-02-21 14-51-20](https://user-images.githubusercontent.com/4232207/108616800-3f1ef380-7454-11eb-93e0-f18cdffeb97a.png)

Essentially what it does is that, it wraps user's content by nested svg with `viewBox: "0 0 100 100"`, so its size is independent from board size itself. A user only needs to author their svg assuming the size of single square is 100x100.

I haven't look through the code base much, so I might be missing something.
Please let me know if this approach is appropriate. Thanks!