### PR TITLE
Separate DOM hierarchy for custom svg

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -108,6 +108,9 @@ cg-container > svg {
   height: 100%;
   pointer-events: none;
   z-index: 2;
+}
+
+cg-container > svg > .cg-shapes {
   opacity: 0.6;
 }
 

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,7 +1,7 @@
 import { HeadlessState } from './state';
 import { setVisible, createEl } from './util';
 import { colors, files, ranks } from './types';
-import { createElement as createSVG } from './svg';
+import { createElement as createSVG, setAttributes } from './svg';
 import { Elements } from './types';
 
 export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boolean): Elements {
@@ -10,6 +10,9 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   //     cg-container (800%)
   //       cg-board
   //       svg
+  //         defs
+  //         g.cg-shapes
+  //         g.cg-custom-svgs
   //       coords.ranks
   //       coords.files
   //       piece.ghost
@@ -37,6 +40,8 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   if (s.drawable.visible && !relative) {
     svg = createSVG('svg');
     svg.appendChild(createSVG('defs'));
+    svg.appendChild(setAttributes(createSVG('g'), { 'class': 'cg-shapes' }));
+    svg.appendChild(setAttributes(createSVG('g'), { 'class': 'cg-custom-svgs' }));
     container.appendChild(svg);
   }
 


### PR DESCRIPTION
EDIT: I found one issue regarding z-index when integrating on lichess. I'll try to handle it first. In the mean time, I'll make this PR as draft.

Improvment over https://github.com/ornicar/chessground/pull/173, this PR implements separate dom hierarchy for original shapes and custom svgs.

In effect, changes are like this:

BEFORE

```
<svg>
  <defs>
    ...(for brushes)...
  </defs>
  ...(for arrows, circles, pieces, and custom svgs)...
</svg>
```

AFTER

```
<svg>
  <defs>
    ...(for brushes)...
  </defs>
  <g class="cg-shapes">
    ...(for arrows, circles, and pieces)...
  </g>
  <g class="cg-custom-svgs">
    ...(for custom svgs)...
  </g>
</svg>
```

This enables, for example, applying opacity only to "cg-shapes" and not to "cg-custom-svgs".

Btw, I was wondering whether I should commit `dist` folder (transpiled js files) into the PR.
I didn't do it for the previous PR but do you prefer to commit them here?