### PR TITLE
Separate DOM hierarchy for custom svg (v2)

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -66,7 +66,7 @@ cg-board square.last-move {
 
 cg-board piece.dragging {
   cursor: move;
-  z-index: 9;
+  z-index: 10;
 }
 
 piece.anim {
@@ -98,17 +98,24 @@ piece.fading {
   opacity: 0.5;
 }
 
-/* NOTE: Only direct descendent so that it won't affect nested svg from DrawShape.customSvg */
-cg-container > svg {
+.cg-wrap .cg-shapes, .cg-wrap .cg-custom-svgs {
   overflow: hidden;
-  position: relative;
+  position: absolute;
   top: 0px;
   left: 0px;
   width: 100%;
   height: 100%;
   pointer-events: none;
-  z-index: 2;
+}
+
+.cg-wrap .cg-shapes {
   opacity: 0.6;
+  z-index: 2;
+}
+
+.cg-wrap .cg-custom-svgs {
+  /* over piece.anim = 8, but under piece.dragging = 10 */
+  z-index: 9;
 }
 
 .cg-wrap coords {

--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -22,12 +22,12 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
       bounds = util.memo(() => elements.board.getBoundingClientRect()),
       redrawNow = (skipSvg?: boolean): void => {
         render(state);
-        if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg);
+        if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg, elements.customSvg!);
       },
       boundsUpdated = (): void => {
         bounds.clear();
         updateBounds(state);
-        if (elements.svg) svg.renderSvg(state, elements.svg);
+        if (elements.svg) svg.renderSvg(state, elements.svg, elements.customSvg!);
       };
     const state = maybeState as State;
     state.dom = {

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -6,7 +6,7 @@ import * as cg from './types';
 export interface DrawShape {
   orig: cg.Key;
   dest?: cg.Key;
-  brush: string;
+  brush?: string;
   modifiers?: DrawModifiers;
   piece?: DrawShapePiece;
   customSvg?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Elements {
   container: HTMLElement;
   ghost?: HTMLElement;
   svg?: SVGElement;
+  customSvg?: SVGElement;
 }
 export interface Dom {
   elements: Elements;

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,7 +1,7 @@
 import { HeadlessState } from './state';
 import { setVisible, createEl } from './util';
 import { colors, files, ranks } from './types';
-import { createElement as createSVG } from './svg';
+import { createElement as createSVG, setAttributes } from './svg';
 import { Elements } from './types';
 
 export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boolean): Elements {
@@ -9,7 +9,11 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   //   cg-helper (12.5%, display: table)
   //     cg-container (800%)
   //       cg-board
-  //       svg
+  //       svg.cg-shapes
+  //         defs
+  //         g
+  //       svg.cg-custom-svgs
+  //         g
   //       coords.ranks
   //       coords.files
   //       piece.ghost
@@ -34,10 +38,15 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   container.appendChild(board);
 
   let svg: SVGElement | undefined;
+  let customSvg: SVGElement | undefined;
   if (s.drawable.visible && !relative) {
-    svg = createSVG('svg');
+    svg = setAttributes(createSVG('svg'), { 'class': 'cg-shapes' });
     svg.appendChild(createSVG('defs'));
+    svg.appendChild(createSVG('g'));
+    customSvg = setAttributes(createSVG('svg'), { 'class': 'cg-custom-svgs' });
+    customSvg.appendChild(createSVG('g'));
     container.appendChild(svg);
+    container.appendChild(customSvg);
   }
 
   if (s.coordinates) {
@@ -58,6 +67,7 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
     container,
     ghost,
     svg,
+    customSvg,
   };
 }
 


### PR DESCRIPTION
I found the previous PR https://github.com/ornicar/chessground/pull/174 can handle opacity but is no so flexible regarding z-index. This PR attempts to solve that issue by separating the root svg.

The change in DOM hierarchy is as follows:

BEFORE

```
<svg>
  <defs>
    ...(for brushes)...
  </defs>
  ...(for arrows, circles, pieces, and custom svgs)...
</svg>
```

AFTER

```
<svg class="cg-shapes">
  <defs>
    ...(for brushes)...
  </defs>
  <g>
    ...(for arrows, circles, and pieces)...
  </g>
</svg>
<svg class="cg-custom-svgs">
  <g>
    ...(for custom svgs)...
  </g>
</svg>
```

The change in DOM hierarchy is more drastic than before. I hope it's not breaking anything.