### PR TITLE
Update eraseOnClick logic

### DIFF
--- a/src/drag.ts
+++ b/src/drag.ts
@@ -27,7 +27,7 @@ export function start(s: State, e: cg.MouchEvent): void {
   if (!orig) return;
   const piece = s.pieces.get(orig);
   const previouslySelected = s.selected;
-  if (!previouslySelected && s.drawable.enabled && (s.drawable.eraseOnClick || !piece || piece.color !== s.turnColor))
+  if (!previouslySelected && s.drawable.enabled && s.drawable.eraseOnClick)
     drawClear(s);
   // Prevent touch scroll and create no corresponding mouse event, if there
   // is an intent to interact with the board. If no color is movable


### PR DESCRIPTION
## Old Logic
Assuming white to move
### eraseOnClick=true
* Clicking anywhere will clear shapes
### eraseOnClick=false
* Clicking on white piece will not clear shapes
* Clicking on black/no piece will clear shapes (bug)
## New Logic
### eraseOnClick=true
* Clicking anywhere will clear shapes
### eraseOnClick=false
* Clicking anywhere will not clear shapes