### PR TITLE
Update arrow yellow colour from gold to yellow

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -169,7 +169,7 @@ export function defaults(): HeadlessState {
         green: { key: 'g', color: '#15781B', opacity: 1, lineWidth: 10 },
         red: { key: 'r', color: '#882020', opacity: 1, lineWidth: 10 },
         blue: { key: 'b', color: '#003088', opacity: 1, lineWidth: 10 },
-        yellow: { key: 'y', color: '#e68f00', opacity: 1, lineWidth: 10 },
+        yellow: { key: 'y', color: '#ffff00', opacity: 1, lineWidth: 10 },
         paleBlue: { key: 'pb', color: '#003088', opacity: 0.4, lineWidth: 15 },
         paleGreen: { key: 'pg', color: '#15781B', opacity: 0.4, lineWidth: 15 },
         paleRed: { key: 'pr', color: '#882020', opacity: 0.4, lineWidth: 15 },


### PR DESCRIPTION
Hi,

On the Lichess discord, after finding out there was a 4th colour, upon showing Yatrik a screenshot of the current "yellow" arrow, he replied "The pee arrow! :pepefunny:".
I can't unsee that now.

I don't want to create any debate (like the flags) about this for which colour exactly, I'm just bringing it up. Feel free to close the request or update the value I picked if you either think it's not worth the effort to change or if my pick is not best.

I am aware this can be fixed locally with a user script.