### PR TITLE
override autodrawable in config (issue #184)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -90,8 +90,9 @@ export interface Config {
 }
 
 export function configure(state: HeadlessState, config: Config): void {
-  // don't merge destinations. Just override.
+  // don't merge destinations and autoShapes. Just override.
   if (config.movable?.dests) state.movable.dests = undefined;
+  if (config.drawable?.autoShapes) state.drawable.autoShapes = [];
 
   merge(state, config);
 


### PR DESCRIPTION
PR for https://github.com/ornicar/chessground/issues/184

I found that the solution used for handling `moveable.dests` was much simpler than what I had suggested in the issue report (which was to copy what was done for `lastMove`.) So this is a pretty quick one-liner that does the same thing for `autodrawable`.