### PR TITLE
Fix type annotation of drawable.brushes in Config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { HeadlessState } from './state';
 import { setCheck, setSelected } from './board';
 import { read as fenRead } from './fen';
-import { DrawShape, DrawBrush } from './draw';
+import { DrawShape, DrawBrushes } from './draw';
 import * as cg from './types';
 
 export interface Config {
@@ -81,7 +81,7 @@ export interface Config {
     eraseOnClick?: boolean;
     shapes?: DrawShape[];
     autoShapes?: DrawShape[];
-    brushes?: DrawBrush[];
+    brushes?: DrawBrushes;
     pieces?: {
       baseUrl?: string;
     };


### PR DESCRIPTION
The type annotation of the `drawable.brushes` field in `Drawable` state object is `DrawBrushes`, but in `Config` it is simply an array `DrawBrush[]`. This should also be of type `DrawBrushes`, so that merging config with state works correctly and transfers brush keys over correctly.