### PR TITLE
Force 8px board-alignment with JS

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -9,7 +9,7 @@ cg-container {
   width: 100%;
   height: 100%;
   display: block;
-  bottom: 0;
+  top: 0;
 }
 
 cg-board {

--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -4,18 +4,10 @@
   display: block;
 }
 
-cg-helper {
-  position: absolute;
-  width: 12.5%;
-  padding-bottom: 12.5%;
-  display: table; /** hack: round to full pixel size in chrome */
-  bottom: 0;
-}
-
 cg-container {
   position: absolute;
-  width: 800%;
-  height: 800%;
+  width: 100%;
+  height: 100%;
   display: block;
   bottom: 0;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chessground",
-  "version": "8.0.0",
+  "version": "8.0.0-beta1",
   "description": "lichess.org chess ui",
   "type": "module",
   "module": "chessground.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chessground",
-  "version": "8.0.0-beta1",
+  "version": "8.0.0-beta2",
   "description": "lichess.org chess ui",
   "type": "module",
   "module": "chessground.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chessground",
-  "version": "7.12.0",
+  "version": "8.0.0",
   "description": "lichess.org chess ui",
   "type": "module",
   "module": "chessground.js",
@@ -15,7 +15,7 @@
     "rollup": "^2",
     "rollup-plugin-terser": "^7",
     "tslib": "^2",
-    "typescript": "^4"
+    "typescript": "^4.3"
   },
   "scripts": {
     "prepare": "npm run compile",

--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -4,7 +4,7 @@ import { HeadlessState, State, defaults } from './state';
 
 import { renderWrap } from './wrap';
 import * as events from './events';
-import { render, updateBounds } from './render';
+import { render, renderResized, updateBounds } from './render';
 import * as svg from './svg';
 import * as util from './util';
 
@@ -24,9 +24,9 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
         render(state);
         if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg, elements.customSvg!);
       },
-      boundsUpdated = (): void => {
-        bounds.clear();
+      onResize = (): void => {
         updateBounds(state);
+        renderResized(state);
         if (elements.svg) svg.renderSvg(state, elements.svg, elements.customSvg!);
       };
     const state = maybeState as State;
@@ -39,9 +39,10 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
       relative,
     };
     state.drawable.prevSvgHash = '';
+    updateBounds(state);
     redrawNow(false);
-    events.bindBoard(state, boundsUpdated);
-    if (!prevUnbind) state.dom.unbind = events.bindDocument(state, boundsUpdated);
+    events.bindBoard(state, onResize);
+    if (!prevUnbind) state.dom.unbind = events.bindDocument(state, onResize);
     state.events.insert && state.events.insert(elements);
     return state;
   }

--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -17,8 +17,7 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
     const prevUnbind = 'dom' in maybeState ? maybeState.dom.unbind : undefined;
     // compute bounds from existing board element if possible
     // this allows non-square boards from CSS to be handled (for 3D)
-    const relative = maybeState.viewOnly && !maybeState.drawable.visible,
-      elements = renderWrap(element, maybeState, relative),
+    const elements = renderWrap(element, maybeState),
       bounds = util.memo(() => elements.board.getBoundingClientRect()),
       redrawNow = (skipSvg?: boolean): void => {
         render(state);
@@ -36,7 +35,6 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
       redraw: debounceRedraw(redrawNow),
       redrawNow,
       unbind: prevUnbind,
-      relative,
     };
     state.drawable.prevSvgHash = '';
     updateBounds(state);

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,6 @@ export interface Config {
   autoCastle?: boolean; // immediately complete the castle by moving the rook after king move
   viewOnly?: boolean; // don't bind events: the user will never be able to move pieces around
   disableContextMenu?: boolean; // because who needs a context menu on a chessboard
-  resizable?: boolean; // listens to chessground.resize on document.body to clear bounds cache
   addPieceZIndex?: boolean; // adds z-index values to pieces (for 3D)
   // pieceKey: boolean; // add a data-key attribute to piece elements
   highlight?: {

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -65,7 +65,7 @@ export function start(s: State, e: cg.MouchEvent): void {
     const ghost = s.dom.elements.ghost;
     if (ghost) {
       ghost.className = `ghost ${piece.color} ${piece.role}`;
-      util.translateAbs(ghost, util.posToTranslateAbs(bounds)(util.key2pos(orig), board.whitePov(s)));
+      util.translate(ghost, util.posToTranslate(bounds)(util.key2pos(orig), board.whitePov(s)));
       util.setVisible(ghost, true);
     }
     processDrag(s);
@@ -131,7 +131,7 @@ function processDrag(s: State): void {
         }
 
         const bounds = s.dom.bounds();
-        util.translateAbs(cur.element, [
+        util.translate(cur.element, [
           cur.pos[0] - bounds.left - bounds.width / 16,
           cur.pos[1] - bounds.top - bounds.height / 16,
         ]);

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,8 +12,7 @@ export function bindBoard(s: State, boundsUpdated: () => void): void {
   const boardEl = s.dom.elements.board;
 
   if (!s.dom.relative && s.resizable && 'ResizeObserver' in window) {
-    const observer = new (window as any)['ResizeObserver'](boundsUpdated);
-    observer.observe(boardEl);
+    new ResizeObserver(boundsUpdated).observe(s.dom.elements.wrap);
   }
 
   if (s.viewOnly) return;

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,7 +12,8 @@ export function bindBoard(s: State, boundsUpdated: () => void): void {
   const boardEl = s.dom.elements.board;
 
   if (!s.dom.relative && s.resizable && 'ResizeObserver' in window) {
-    new ResizeObserver(boundsUpdated).observe(s.dom.elements.wrap);
+    const observer = new (window as any).ResizeObserver(boundsUpdated);
+    observer.observe(s.dom.elements.wrap);
   }
 
   if (s.viewOnly) return;

--- a/src/events.ts
+++ b/src/events.ts
@@ -11,7 +11,7 @@ type StateMouchBind = (d: State, e: cg.MouchEvent) => void;
 export function bindBoard(s: State, onResize: () => void): void {
   const boardEl = s.dom.elements.board;
 
-  if (!s.dom.relative && s.resizable && 'ResizeObserver' in window) {
+  if (!s.dom.relative && 'ResizeObserver' in window) {
     new ResizeObserver(onResize).observe(s.dom.elements.wrap);
   }
 
@@ -38,7 +38,7 @@ export function bindDocument(s: State, onResize: () => void): cg.Unbind {
 
   // Old versions of Edge and Safari do not support ResizeObserver. Send
   // chessground.resize if a user action has changed the bounds of the board.
-  if (!s.dom.relative && s.resizable && !('ResizeObserver' in window)) {
+  if (!s.dom.relative && !('ResizeObserver' in window)) {
     unbinds.push(unbindable(document.body, 'chessground.resize', onResize));
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -8,11 +8,11 @@ import * as cg from './types';
 type MouchBind = (e: cg.MouchEvent) => void;
 type StateMouchBind = (d: State, e: cg.MouchEvent) => void;
 
-export function bindBoard(s: State, boundsUpdated: () => void): void {
+export function bindBoard(s: State, onResize: () => void): void {
   const boardEl = s.dom.elements.board;
 
   if (!s.dom.relative && s.resizable && 'ResizeObserver' in window) {
-    new ResizeObserver(boundsUpdated).observe(s.dom.elements.wrap);
+    new ResizeObserver(onResize).observe(s.dom.elements.wrap);
   }
 
   if (s.viewOnly) return;
@@ -33,13 +33,13 @@ export function bindBoard(s: State, boundsUpdated: () => void): void {
 }
 
 // returns the unbind function
-export function bindDocument(s: State, boundsUpdated: () => void): cg.Unbind {
+export function bindDocument(s: State, onResize: () => void): cg.Unbind {
   const unbinds: cg.Unbind[] = [];
 
   // Old versions of Edge and Safari do not support ResizeObserver. Send
   // chessground.resize if a user action has changed the bounds of the board.
   if (!s.dom.relative && s.resizable && !('ResizeObserver' in window)) {
-    unbinds.push(unbindable(document.body, 'chessground.resize', boundsUpdated));
+    unbinds.push(unbindable(document.body, 'chessground.resize', onResize));
   }
 
   if (!s.viewOnly) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -11,9 +11,7 @@ type StateMouchBind = (d: State, e: cg.MouchEvent) => void;
 export function bindBoard(s: State, onResize: () => void): void {
   const boardEl = s.dom.elements.board;
 
-  if (!s.dom.relative && 'ResizeObserver' in window) {
-    new ResizeObserver(onResize).observe(s.dom.elements.wrap);
-  }
+  if ('ResizeObserver' in window) new ResizeObserver(onResize).observe(s.dom.elements.wrap);
 
   if (s.viewOnly) return;
 
@@ -38,9 +36,7 @@ export function bindDocument(s: State, onResize: () => void): cg.Unbind {
 
   // Old versions of Edge and Safari do not support ResizeObserver. Send
   // chessground.resize if a user action has changed the bounds of the board.
-  if (!s.dom.relative && !('ResizeObserver' in window)) {
-    unbinds.push(unbindable(document.body, 'chessground.resize', onResize));
-  }
+  if (!('ResizeObserver' in window)) unbinds.push(unbindable(document.body, 'chessground.resize', onResize));
 
   if (!s.viewOnly) {
     const onmove = dragOrDraw(s, drag.move, draw.move);

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,8 +12,7 @@ export function bindBoard(s: State, boundsUpdated: () => void): void {
   const boardEl = s.dom.elements.board;
 
   if (!s.dom.relative && s.resizable && 'ResizeObserver' in window) {
-    const observer = new (window as any).ResizeObserver(boundsUpdated);
-    observer.observe(s.dom.elements.wrap);
+    new ResizeObserver(boundsUpdated).observe(s.dom.elements.wrap);
   }
 
   if (s.viewOnly) return;

--- a/src/render.ts
+++ b/src/render.ts
@@ -174,8 +174,11 @@ export function render(s: State): void {
 export function updateBounds(s: State): void {
   const bounds = s.dom.elements.wrap.getBoundingClientRect();
   const container = s.dom.elements.container;
-  container.style.width = (Math.floor(bounds.width / 8) * 8).toString() + 'px';
-  container.style.height = (Math.floor(bounds.height / 8) * 8).toString() + 'px';
+  const ratio = bounds.height / bounds.width;
+  const width = Math.floor(bounds.width / 8) * 8;
+  const height = width * ratio;
+  container.style.width = width + 'px';
+  container.style.height = height + 'px';
 
   if (s.dom.relative) return;
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -171,15 +171,7 @@ export function render(s: State): void {
   for (const nodes of movedSquares.values()) removeNodes(s, nodes);
 }
 
-export function updateBounds(s: State): void {
-  const bounds = s.dom.elements.wrap.getBoundingClientRect();
-  const container = s.dom.elements.container;
-  const ratio = bounds.height / bounds.width;
-  const width = Math.floor(bounds.width / 8) * 8;
-  const height = width * ratio;
-  container.style.width = width + 'px';
-  container.style.height = height + 'px';
-
+export function renderResized(s: State): void {
   if (s.dom.relative) return;
 
   const asWhite: boolean = whitePov(s),
@@ -191,6 +183,17 @@ export function updateBounds(s: State): void {
     }
     el = el.nextSibling as cg.PieceNode | cg.SquareNode | undefined;
   }
+}
+
+export function updateBounds(s: State) {
+  const bounds = s.dom.elements.wrap.getBoundingClientRect();
+  const container = s.dom.elements.container;
+  const ratio = bounds.height / bounds.width;
+  const width = Math.floor(bounds.width / 8) * 8;
+  const height = width * ratio;
+  container.style.width = width + 'px';
+  container.style.height = height + 'px';
+  s.dom.bounds.clear();
 }
 
 function isPieceNode(el: cg.PieceNode | cg.SquareNode): el is cg.PieceNode {

--- a/src/render.ts
+++ b/src/render.ts
@@ -172,7 +172,13 @@ export function render(s: State): void {
 }
 
 export function updateBounds(s: State): void {
+  const bounds = s.dom.elements.wrap.getBoundingClientRect();
+  const container = s.dom.elements.container;
+  container.style.width = (Math.floor(bounds.width / 8) * 8).toString();
+  container.style.height = (Math.floor(bounds.height / 8) * 8).toString();
+
   if (s.dom.relative) return;
+
   const asWhite: boolean = whitePov(s),
     posToTranslate = posToTranslateAbs(s.dom.bounds());
   let el = s.dom.elements.board.firstChild as cg.PieceNode | cg.SquareNode | undefined;

--- a/src/render.ts
+++ b/src/render.ts
@@ -174,8 +174,8 @@ export function render(s: State): void {
 export function updateBounds(s: State): void {
   const bounds = s.dom.elements.wrap.getBoundingClientRect();
   const container = s.dom.elements.container;
-  container.style.width = (Math.floor(bounds.width / 8) * 8).toString();
-  container.style.height = (Math.floor(bounds.height / 8) * 8).toString();
+  container.style.width = (Math.floor(bounds.width / 8) * 8).toString() + 'px';
+  container.style.height = (Math.floor(bounds.height / 8) * 8).toString() + 'px';
 
   if (s.dom.relative) return;
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,5 @@
 import { State } from './state';
-import { key2pos, createEl, posToTranslateRel, posToTranslateAbs, translateRel, translateAbs } from './util';
+import { key2pos, createEl, posToTranslate as posToTranslateFromBounds, translate } from './util';
 import { whitePov } from './board';
 import { AnimCurrent, AnimVectors, AnimVector, AnimFadings } from './anim';
 import { DragCurrent } from './drag';
@@ -13,8 +13,7 @@ type SquareClasses = Map<cg.Key, string>;
 // in case of bugs, blame @veloce
 export function render(s: State): void {
   const asWhite: boolean = whitePov(s),
-    posToTranslate = s.dom.relative ? posToTranslateRel : posToTranslateAbs(s.dom.bounds()),
-    translate = s.dom.relative ? translateRel : translateAbs,
+    posToTranslate = posToTranslateFromBounds(s.dom.bounds()),
     boardEl: HTMLElement = s.dom.elements.board,
     pieces: cg.Pieces = s.pieces,
     curAnim: AnimCurrent | undefined = s.animation.current,
@@ -172,14 +171,12 @@ export function render(s: State): void {
 }
 
 export function renderResized(s: State): void {
-  if (s.dom.relative) return;
-
   const asWhite: boolean = whitePov(s),
-    posToTranslate = posToTranslateAbs(s.dom.bounds());
+    posToTranslate = posToTranslateFromBounds(s.dom.bounds());
   let el = s.dom.elements.board.firstChild as cg.PieceNode | cg.SquareNode | undefined;
   while (el) {
     if ((isPieceNode(el) && !el.cgAnimating) || isSquareNode(el)) {
-      translateAbs(el, posToTranslate(key2pos(el.cgKey), asWhite));
+      translate(el, posToTranslate(key2pos(el.cgKey), asWhite));
     }
     el = el.nextSibling as cg.PieceNode | cg.SquareNode | undefined;
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,7 +16,6 @@ export interface HeadlessState {
   autoCastle: boolean; // immediately complete the castle by moving the rook after king move
   viewOnly: boolean; // don't bind events: the user will never be able to move pieces around
   disableContextMenu: boolean; // because who needs a context menu on a chessboard
-  resizable: boolean; // listens to chessground.resize on document.body to clear bounds cache
   addPieceZIndex: boolean; // adds z-index values to pieces (for 3D)
   pieceKey: boolean; // add a data-key attribute to piece elements
   highlight: {
@@ -111,7 +110,6 @@ export function defaults(): HeadlessState {
     autoCastle: true,
     viewOnly: false,
     disableContextMenu: false,
-    resizable: true,
     addPieceZIndex: false,
     pieceKey: false,
     highlight: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,6 @@ export interface Dom {
   redrawNow: (skipSvg?: boolean) => void;
   unbind?: Unbind;
   destroyed?: boolean;
-  relative?: boolean; // don't compute bounds, use relative % to place pieces
 }
 export interface Exploding {
   stage: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export type Dests = Map<Key, Key[]>;
 
 export interface Elements {
   board: HTMLElement;
+  wrap: HTMLElement;
   container: HTMLElement;
   ghost?: HTMLElement;
   svg?: SVGElement;

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,26 +50,13 @@ export const distanceSq = (pos1: cg.Pos, pos2: cg.Pos): number => {
 
 export const samePiece = (p1: cg.Piece, p2: cg.Piece): boolean => p1.role === p2.role && p1.color === p2.color;
 
-const posToTranslateBase = (pos: cg.Pos, asWhite: boolean, xFactor: number, yFactor: number): cg.NumberPair => [
-  (asWhite ? pos[0] : 7 - pos[0]) * xFactor,
-  (asWhite ? 7 - pos[1] : pos[1]) * yFactor,
-];
+export const posToTranslate =
+  (bounds: ClientRect): ((pos: cg.Pos, asWhite: boolean) => cg.NumberPair) =>
+  (pos, asWhite) =>
+    [((asWhite ? pos[0] : 7 - pos[0]) * bounds.width) / 8, ((asWhite ? 7 - pos[1] : pos[1]) * bounds.height) / 8];
 
-export const posToTranslateAbs = (bounds: ClientRect): ((pos: cg.Pos, asWhite: boolean) => cg.NumberPair) => {
-  const xFactor = bounds.width / 8,
-    yFactor = bounds.height / 8;
-  return (pos, asWhite) => posToTranslateBase(pos, asWhite, xFactor, yFactor);
-};
-
-export const posToTranslateRel = (pos: cg.Pos, asWhite: boolean): cg.NumberPair =>
-  posToTranslateBase(pos, asWhite, 100, 100);
-
-export const translateAbs = (el: HTMLElement, pos: cg.NumberPair): void => {
+export const translate = (el: HTMLElement, pos: cg.NumberPair): void => {
   el.style.transform = `translate(${pos[0]}px,${pos[1]}px)`;
-};
-
-export const translateRel = (el: HTMLElement, percents: cg.NumberPair): void => {
-  el.style.transform = `translate(${percents[0]}%,${percents[1]}%)`;
 };
 
 export const setVisible = (el: HTMLElement, v: boolean): void => {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -28,12 +28,6 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   element.classList.toggle('manipulable', !s.viewOnly);
 
   const container = createEl('cg-container');
-  const bounds = element.getBoundingClientRect();
-  const ratio = bounds.height / bounds.width;
-  const width = Math.floor(bounds.width / 8) * 8;
-  const height = width * ratio;
-  container.style.width = width + 'px';
-  container.style.height = height + 'px';
   element.appendChild(container);
 
   const board = createEl('cg-board');

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -3,7 +3,7 @@ import { setVisible, createEl } from './util';
 import { colors, files, ranks, Elements } from './types';
 import { createElement as createSVG, setAttributes } from './svg';
 
-export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boolean): Elements {
+export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
   // .cg-wrap (element passed to Chessground)
   //   cg-container
   //     cg-board
@@ -35,7 +35,7 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
 
   let svg: SVGElement | undefined;
   let customSvg: SVGElement | undefined;
-  if (s.drawable.visible && !relative) {
+  if (s.drawable.visible) {
     svg = setAttributes(createSVG('svg'), { class: 'cg-shapes' });
     svg.appendChild(createSVG('defs'));
     svg.appendChild(createSVG('g'));
@@ -52,7 +52,7 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   }
 
   let ghost: HTMLElement | undefined;
-  if (s.draggable.showGhost && !relative) {
+  if (s.draggable.showGhost) {
     ghost = createEl('piece', 'ghost');
     setVisible(ghost, false);
     container.appendChild(ghost);

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -5,17 +5,16 @@ import { createElement as createSVG, setAttributes } from './svg';
 
 export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boolean): Elements {
   // .cg-wrap (element passed to Chessground)
-  //   cg-helper (12.5%, display: table)
-  //     cg-container (800%)
-  //       cg-board
-  //       svg.cg-shapes
-  //         defs
-  //         g
-  //       svg.cg-custom-svgs
-  //         g
-  //       coords.ranks
-  //       coords.files
-  //       piece.ghost
+  //   cg-container
+  //     cg-board
+  //     svg.cg-shapes
+  //       defs
+  //       g
+  //     svg.cg-custom-svgs
+  //       g
+  //     coords.ranks
+  //     coords.files
+  //     piece.ghost
 
   element.innerHTML = '';
 
@@ -28,10 +27,11 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   for (const c of colors) element.classList.toggle('orientation-' + c, s.orientation === c);
   element.classList.toggle('manipulable', !s.viewOnly);
 
-  const helper = createEl('cg-helper');
-  element.appendChild(helper);
   const container = createEl('cg-container');
-  helper.appendChild(container);
+  const bounds = element.getBoundingClientRect();
+  container.style.width = (Math.floor(bounds.width / 8) * 8).toString();
+  container.style.height = (Math.floor(bounds.height / 8) * 8).toString();
+  element.appendChild(container);
 
   const board = createEl('cg-board');
   container.appendChild(board);
@@ -64,6 +64,7 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
   return {
     board,
     container,
+    wrap: element,
     ghost,
     svg,
     customSvg,

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -29,8 +29,11 @@ export function renderWrap(element: HTMLElement, s: HeadlessState, relative: boo
 
   const container = createEl('cg-container');
   const bounds = element.getBoundingClientRect();
-  container.style.width = (Math.floor(bounds.width / 8) * 8).toString();
-  container.style.height = (Math.floor(bounds.height / 8) * 8).toString();
+  const ratio = bounds.height / bounds.width;
+  const width = Math.floor(bounds.width / 8) * 8;
+  const height = width * ratio;
+  container.style.width = width + 'px';
+  container.style.height = height + 'px';
   element.appendChild(container);
 
   const board = createEl('cg-board');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,10 +1115,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@^4.3:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Closes #51
Related ornicar/lila#8114

Since the table hack stopped working in Chrome 91 and probably won't be coming back, we might as well finally do it with JS. Since it only adjusts the size slightly and the element still has a default `width/height: 100%` it shouldn't have a big impact on the initial load and still show the board immediately.

I also spent some time trying to remove the requirement for the 8px alignment, which seems like it would be nicer in general, but it doesn't really seem possible without some browser detection and extended studying of Chrome's confusing image scaling algorithm. Avoiding the blurry pieces actually seems fairly easy by avoiding `will-change: transform` when nothing is actually moving but aligning the highlight squares is a completely different matter. I even tried to render a test image onto an offscreen canvas to auto-detect how the browser does things, which actually works in some cases, but somehow, `background-size: cover` does something slightly differently and sometimes shifts certain lines over by 1px.