### PR TITLE
Scale svgs without javascript

### DIFF
--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -26,7 +26,6 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
       onResize = (): void => {
         updateBounds(state);
         renderResized(state);
-        if (elements.svg) svg.renderSvg(state, elements.svg, elements.customSvg!);
       };
     const state = maybeState as State;
     state.dom = {

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -255,15 +255,16 @@ function renderArrow(brush: DrawBrush, orig: cg.Pos, dest: cg.Pos, current: bool
 
 function renderPiece(baseUrl: string, pos: cg.Pos, piece: DrawShapePiece): SVGElement {
   const o = pos2user(pos),
-    size = piece.scale || 1,
     name = piece.color[0] + (piece.role === 'knight' ? 'n' : piece.role[0]).toUpperCase();
   return setAttributes(createElement('image'), {
     className: `${piece.role} ${piece.color}`,
-    x: o[0] - size / 2,
-    y: o[1] - size / 2,
-    width: size,
-    height: size,
+    x: o[0] - 0.5,
+    y: o[1] - 0.5,
+    width: 1,
+    height: 1,
     href: baseUrl + name + '.svg',
+    transform: `scale(${piece.scale || 1})`,
+    'transform-origin': `${o[0]} ${o[1]}`,
   });
 }
 
@@ -309,7 +310,7 @@ function circleWidth(): [number, number] {
 }
 
 function lineWidth(brush: DrawBrush, current: boolean): number {
-  return (brush.lineWidth || 10) * (current ? 0.85 : 1) / 64;
+  return ((brush.lineWidth || 10) * (current ? 0.85 : 1)) / 64;
 }
 
 function opacity(brush: DrawBrush, current: boolean): number {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -36,10 +36,10 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
   let svg: SVGElement | undefined;
   let customSvg: SVGElement | undefined;
   if (s.drawable.visible) {
-    svg = setAttributes(createSVG('svg'), { class: 'cg-shapes' });
+    svg = setAttributes(createSVG('svg'), { class: 'cg-shapes', viewBox: '-.5 -.5 8 8' });
     svg.appendChild(createSVG('defs'));
     svg.appendChild(createSVG('g'));
-    customSvg = setAttributes(createSVG('svg'), { class: 'cg-custom-svgs' });
+    customSvg = setAttributes(createSVG('svg'), { class: 'cg-custom-svgs', viewBox: '0 0 8 8' });
     customSvg.appendChild(createSVG('g'));
     container.appendChild(svg);
     container.appendChild(customSvg);


### PR DESCRIPTION
Changes shapes and custom-shapes to use user coordinates instead of viewport (px) units. This lets us skip `renderSvg` on resize and fixes #197. I never actually found out what caused that bug.

Minified, 26431 -> 26183 byes. Barely 0.9% smaller.