### PR TITLE
Use selected piece set for auto pieces

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -86,9 +86,10 @@ piece.fading {
   opacity: 0.6;
 }
 
+.cg-wrap cg-auto-pieces,
 .cg-wrap .cg-shapes,
 .cg-wrap .cg-custom-svgs {
-  overflow: hidden;
+  overflow: visible;
   position: absolute;
   top: 0px;
   left: 0px;
@@ -97,19 +98,23 @@ piece.fading {
   pointer-events: none;
 }
 
-.cg-wrap .cg-shapes {
-  opacity: 0.6;
+.cg-wrap cg-auto-pieces {
   z-index: 2;
 }
 
-.cg-wrap .cg-shapes .cg-shape-piece {
-  opacity: 0.5;
+.cg-wrap cg-auto-pieces piece {
+  opacity: 0.3;
+}
+
+.cg-wrap .cg-shapes {
+  overflow: hidden;
+  opacity: 0.6;
+  z-index: 2;
 }
 
 .cg-wrap .cg-custom-svgs {
   /* over piece.anim = 8, but under piece.dragging = 10 */
   z-index: 9;
-  overflow: visible;
 }
 
 .cg-wrap .cg-custom-svgs svg {

--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -86,10 +86,6 @@ piece.fading {
   opacity: 0.6;
 }
 
-.cg-wrap piece svg image {
-  opacity: 0.5;
-}
-
 .cg-wrap .cg-shapes,
 .cg-wrap .cg-custom-svgs {
   overflow: hidden;
@@ -104,6 +100,10 @@ piece.fading {
 .cg-wrap .cg-shapes {
   opacity: 0.6;
   z-index: 2;
+}
+
+.cg-wrap .cg-shapes .cg-shape-piece {
+  opacity: 0.5;
 }
 
 .cg-wrap .cg-custom-svgs {

--- a/src/autoPieces.ts
+++ b/src/autoPieces.ts
@@ -1,0 +1,48 @@
+import { State } from './state';
+import { key2pos, createEl, posToTranslate as posToTranslateFromBounds, translateAndScale } from './util';
+import { whitePov } from './board';
+import * as cg from './types';
+import { DrawShape } from './draw';
+import { SyncableShape, Hash, syncShapes } from './sync';
+
+export function render(state: State, autoPieceEl: HTMLElement): void {
+  const autoPieces = state.drawable.autoShapes.filter(autoShape => autoShape.piece);
+  const autoPieceShapes: SyncableShape[] = autoPieces.map((s: DrawShape) => {
+    return {
+      shape: s,
+      hash: hash(s),
+      current: false,
+    };
+  });
+
+  syncShapes(autoPieceShapes, autoPieceEl, shape => renderShape(state, shape, state.dom.bounds()));
+}
+
+export function renderResized(state: State): void {
+  const asWhite: boolean = whitePov(state),
+    posToTranslate = posToTranslateFromBounds(state.dom.bounds());
+  let el = state.dom.elements.autoPieces?.firstChild as cg.PieceNode | undefined;
+  while (el) {
+    translateAndScale(el, posToTranslate(key2pos(el.cgKey), asWhite), el.cgScale);
+    el = el.nextSibling as cg.PieceNode | undefined;
+  }
+}
+
+function renderShape(state: State, { shape, hash }: SyncableShape, bounds: ClientRect): cg.PieceNode {
+  const orig = shape.orig;
+  const role = shape.piece?.role;
+  const color = shape.piece?.color;
+  const scale = shape.piece?.scale;
+
+  const pieceEl = createEl('piece', `${role} ${color}`) as cg.PieceNode;
+  pieceEl.setAttribute('cgHash', hash);
+  pieceEl.cgKey = orig;
+  pieceEl.cgScale = scale;
+  translateAndScale(pieceEl, posToTranslateFromBounds(bounds)(key2pos(orig), whitePov(state)), scale);
+
+  return pieceEl;
+}
+
+function hash(autoPiece: DrawShape): Hash {
+  return [autoPiece.orig, autoPiece.piece?.role, autoPiece.piece?.color, autoPiece.piece?.scale].join(',');
+}

--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -5,6 +5,7 @@ import { HeadlessState, State, defaults } from './state';
 import { renderWrap } from './wrap';
 import * as events from './events';
 import { render, renderResized, updateBounds } from './render';
+import * as autoPieces from './autoPieces';
 import * as svg from './svg';
 import * as util from './util';
 
@@ -21,11 +22,13 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
       bounds = util.memo(() => elements.board.getBoundingClientRect()),
       redrawNow = (skipSvg?: boolean): void => {
         render(state);
+        if (elements.autoPieces) autoPieces.render(state, elements.autoPieces);
         if (!skipSvg && elements.svg) svg.renderSvg(state, elements.svg, elements.customSvg!);
       },
       onResize = (): void => {
         updateBounds(state);
         renderResized(state);
+        if (elements.autoPieces) autoPieces.renderResized(state);
       };
     const state = maybeState as State;
     state.dom = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,9 +85,6 @@ export interface Config {
     shapes?: DrawShape[];
     autoShapes?: DrawShape[];
     brushes?: DrawBrushes;
-    pieces?: {
-      baseUrl?: string;
-    };
     onChange?: (shapes: DrawShape[]) => void; // called after drawable shapes change
   };
 }

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -43,10 +43,6 @@ export interface Drawable {
   autoShapes: DrawShape[]; // computer shapes
   current?: DrawCurrent;
   brushes: DrawBrushes;
-  // drawable SVG pieces; used for crazyhouse drop
-  pieces: {
-    baseUrl: string;
-  };
   prevSvgHash: string;
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -182,9 +182,6 @@ export function defaults(): HeadlessState {
           lineWidth: 15,
         },
       },
-      pieces: {
-        baseUrl: 'https://lichess1.org/assets/piece/cburnett/',
-      },
       prevSvgHash: '',
     },
     hold: timer(),

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,0 +1,36 @@
+import { DrawShape } from './draw';
+
+export interface SyncableShape {
+  shape: DrawShape;
+  current: boolean;
+  hash: Hash;
+}
+
+export type Hash = string;
+
+// append and remove only. No updates.
+export function syncShapes(
+  shapes: SyncableShape[],
+  root: HTMLElement | SVGElement,
+  renderShape: (shape: SyncableShape) => HTMLElement | SVGElement
+): void {
+  const hashesInDom = new Map(), // by hash
+    toRemove: SVGElement[] = [];
+  for (const sc of shapes) hashesInDom.set(sc.hash, false);
+  let el: SVGElement | undefined = root.firstChild as SVGElement,
+    elHash: Hash | null;
+  while (el) {
+    elHash = el.getAttribute('cgHash') as Hash;
+    // found a shape element that's here to stay
+    if (hashesInDom.has(elHash)) hashesInDom.set(elHash, true);
+    // or remove it
+    else toRemove.push(el);
+    el = el.nextSibling as SVGElement | undefined;
+  }
+  // remove old shapes
+  for (const el of toRemove) root.removeChild(el);
+  // insert shapes that are not yet in dom
+  for (const sc of shapes) {
+    if (!hashesInDom.get(sc.hash)) root.appendChild(renderShape(sc));
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface Elements {
   ghost?: HTMLElement;
   svg?: SVGElement;
   customSvg?: SVGElement;
+  autoPieces?: HTMLElement;
 }
 export interface Dom {
   elements: Elements;
@@ -75,6 +76,7 @@ export interface PieceNode extends KeyedNode {
   cgAnimating?: boolean;
   cgFading?: boolean;
   cgDragging?: boolean;
+  cgScale?: number;
 }
 export interface SquareNode extends KeyedNode {
   tagName: 'SQUARE';

--- a/src/util.ts
+++ b/src/util.ts
@@ -59,6 +59,10 @@ export const translate = (el: HTMLElement, pos: cg.NumberPair): void => {
   el.style.transform = `translate(${pos[0]}px,${pos[1]}px)`;
 };
 
+export const translateAndScale = (el: HTMLElement, pos: cg.NumberPair, scale = 1): void => {
+  el.style.transform = `translate(${pos[0]}px,${pos[1]}px) scale(${scale})`;
+};
+
 export const setVisible = (el: HTMLElement, v: boolean): void => {
   el.style.visibility = v ? 'visible' : 'hidden';
 };

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -12,6 +12,7 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
   //       g
   //     svg.cg-custom-svgs
   //       g
+  //     cg-auto-pieces
   //     coords.ranks
   //     coords.files
   //     piece.ghost
@@ -35,6 +36,8 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
 
   let svg: SVGElement | undefined;
   let customSvg: SVGElement | undefined;
+  let autoPieces: HTMLElement | undefined;
+
   if (s.drawable.visible) {
     svg = setAttributes(createSVG('svg'), {
       class: 'cg-shapes',
@@ -43,14 +46,19 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
     });
     svg.appendChild(createSVG('defs'));
     svg.appendChild(createSVG('g'));
+
     customSvg = setAttributes(createSVG('svg'), {
       class: 'cg-custom-svgs',
       viewBox: '-3.5 -3.5 8 8',
       preserveAspectRatio: 'xMidYMid slice',
     });
     customSvg.appendChild(createSVG('g'));
+
+    autoPieces = createEl('cg-auto-pieces');
+
     container.appendChild(svg);
     container.appendChild(customSvg);
+    container.appendChild(autoPieces);
   }
 
   if (s.coordinates) {
@@ -73,6 +81,7 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
     ghost,
     svg,
     customSvg,
+    autoPieces,
   };
 }
 


### PR DESCRIPTION
For ornicar/lila#8302

Currently auto pieces are displayed as images in SVG shape layer and they always appear in the default (cburnett) piece set instead of the piece set selected by a user.

This could be resolved by moving auto pieces from SVG to a separate HTML layer. This allows to use the same HTML elements, classes and styles as for normal pieces. As a result auto pieces will also appear in the selected piece set.

This resolves all the situations where auto pieces are appearing, not just the situation described in the issue (promoting suggestion in analysis board). Other situations where this is relevant are, for instance, premove with a promotion in a game and drop suggestion in Crazyhouse analysis board. Probably there is more.

Tested with both 2D and 3D boards in Firefox, Chrome and Safari.

P.S. Small CSS adjustments will be needed in _lila_  in case if this PR is merged. Here is a PR draft for it - ornicar/lila#9711.

|        | Before | After |
| ------ | ------ | ----- |
| Promoting suggestion (analysis) | ![promotion-suggestion-before](https://user-images.githubusercontent.com/66057996/132664001-fdf4d693-69c3-4b94-9730-2c993ee1b21d.png) | ![promotion-suggestion-after](https://user-images.githubusercontent.com/66057996/132664045-543b6608-bd91-433e-b88f-d2022cc5c8a7.png) |
| Premove with a promotion | ![pre-promotion-before](https://user-images.githubusercontent.com/66057996/132658402-ff7e2194-d292-4961-9f8b-5448eac33622.png) | ![pre-promotion-after](https://user-images.githubusercontent.com/66057996/132658346-7e73a2eb-c23f-4d8b-9c23-12747a49a179.png) |
| Drop suggestion (analysis, Crazyhouse) | ![drop-suggestion-before](https://user-images.githubusercontent.com/66057996/132664158-9a9e681d-6e51-4155-a14c-04d8e54d0c8e.png) | ![drop-suggestion-after](https://user-images.githubusercontent.com/66057996/132664204-5da4b1fa-1f62-475a-9fdc-339be7550465.png) |
| 3D board example | ![promotion-suggestion-3d-before](https://user-images.githubusercontent.com/66057996/132424349-54a9193a-37ca-45b3-965b-69a99ff257c8.png) | ![promotion-suggestion-3d-after](https://user-images.githubusercontent.com/66057996/132424353-32965d7a-9d7d-45fe-8544-881cb3e9e4e1.png) |
