### PR TITLE
Fix dragging 3d piece elevation

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -58,7 +58,8 @@ cg-board square.last-move {
 
 cg-board piece.dragging {
   cursor: move;
-  z-index: 10;
+  /* !important to override z-index from 3D piece inline style */
+  z-index: 11 !important;
 }
 
 piece.anim {
@@ -107,7 +108,7 @@ piece.fading {
 }
 
 .cg-wrap .cg-custom-svgs {
-  /* over piece.anim = 8, but under piece.dragging = 10 */
+  /* over piece.anim = 8, but under piece.dragging = 11 */
   z-index: 9;
   overflow: visible;
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -210,9 +210,11 @@ function removeNodes(s: State, nodes: HTMLElement[]): void {
 }
 
 function posZIndex(pos: cg.Pos, asWhite: boolean): string {
-  let z = 3 + pos[1] * 8 + (7 - pos[0]);
-  if (asWhite) z = 69 - z;
-  return z + '';
+  const minZ = 3;
+  const rank = pos[1];
+  const z = asWhite ? minZ + 7 - rank : minZ + rank;
+
+  return `${z}`;
 }
 
 function pieceNameOf(piece: cg.Piece): string {


### PR DESCRIPTION
Currently _dragging z-index_ set in CSS is not applying to 3D pieces cause piece's _z-index_ set as inline style overwrites it. As a result dragging piece might be displayed under other pieces.

https://user-images.githubusercontent.com/66057996/134406773-54b0be2c-8605-4fb8-9c22-c374ec644217.mp4

This could be fixed by adding _!important_ rule to _dragging z-index_ in CSS.

Naturally, it's not the best practice to rely on _!important_ rule, but since _z-index_ for 3D pieces is set as an inline style that is the only option to override it. Other option could be reusing inline styles, i.e., setting _dragging z-index_ on drag start and setting back _normal z-index_ on drag end, but this looks less pragmatic since the same _dragging z-index_ would be defined in both _css_ and _js_ in this case.

Also small improvement related to the _z-index_ values has been made. Currently each square gives a unique index value to a piece so a very wide range of indices (3-66) is reserved because of that. However having different indices within one rank doesn't seem to make any sense cause 3D pieces only overflow square's top edge and not left/right edges. So one index per rank seems to be more than enough and it allows to significantly reduce the range of indices (3-10). As a result there will be less probability to run into some issues with displaying other things on different layers correctly.

Dragging piece's _z-index_ value has been increased to 11. Currently it's 10 which would display a dragging piece under most of the other pieces even with the _!important_.

I've prepared a PR in _lila_ (ornicar/lila#9865) which also applies _!important_ rule for dragging piece's _z-index_. Since it's value is way higher than in chessground's CSS (204) it doesn't depend on this PR and could be merged separately.