### PR TITLE
Extend coordinates option to allow left position

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -138,6 +138,11 @@ piece.fading {
   flex-flow: column;
 }
 
+.cg-wrap coords.ranks.left {
+  left: -15px;
+  align-items: flex-end;
+}
+
 .cg-wrap coords.files {
   bottom: -4px;
   left: 24px;

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,6 +13,7 @@ export interface HeadlessState {
   lastMove?: cg.Key[]; // squares part of the last move ["c3"; "c4"]
   selected?: cg.Key; // square currently selected "a1"
   coordinates: boolean; // include coords attributes
+  ranksPosition: cg.RanksPosition // position ranks on either side. left | right
   autoCastle: boolean; // immediately complete the castle by moving the rook after king move
   viewOnly: boolean; // don't bind events: the user will never be able to move pieces around
   disableContextMenu: boolean; // because who needs a context menu on a chessboard
@@ -109,6 +110,7 @@ export function defaults(): HeadlessState {
     orientation: 'white',
     turnColor: 'white',
     coordinates: true,
+    ranksPosition: 'right',
     autoCastle: true,
     viewOnly: false,
     disableContextMenu: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,3 +99,5 @@ export type KHz = number;
 export const colors = ['white', 'black'] as const;
 export const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 export const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'] as const;
+
+export type RanksPosition = 'left' | 'right';

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -55,7 +55,8 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
 
   if (s.coordinates) {
     const orientClass = s.orientation === 'black' ? ' black' : '';
-    container.appendChild(renderCoords(ranks, 'ranks' + orientClass));
+    const ranksPositionClass = s.ranksPosition === 'left' ? ' left' : '';
+    container.appendChild(renderCoords(ranks, 'ranks' + orientClass + ranksPositionClass));
     container.appendChild(renderCoords(files, 'files' + orientClass));
   }
 


### PR DESCRIPTION
Adds an option to have the ranks be displayed on the left side of the board, defaulting to the right side as before.

![image](https://user-images.githubusercontent.com/5367666/146449591-aa99257a-3350-43ec-a61c-f7b0bd3a3941.png)