### PR TITLE
Fix invalid es module output, fixes #213

### DIFF
--- a/src/anim.ts
+++ b/src/anim.ts
@@ -1,6 +1,6 @@
-import { State } from './state';
-import * as util from './util';
-import * as cg from './types';
+import { State } from './state.js';
+import * as util from './util.js';
+import * as cg from './types.js';
 
 export type Mutation<A> = (state: State) => A;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,12 @@
-import { State } from './state';
-import * as board from './board';
-import { write as fenWrite } from './fen';
-import { Config, configure, applyAnimation } from './config';
-import { anim, render } from './anim';
-import { cancel as dragCancel, dragNewPiece } from './drag';
-import { DrawShape } from './draw';
-import { explosion } from './explosion';
-import * as cg from './types';
+import { State } from './state.js';
+import * as board from './board.js';
+import { write as fenWrite } from './fen.js';
+import { Config, configure, applyAnimation } from './config.js';
+import { anim, render } from './anim.js';
+import { cancel as dragCancel, dragNewPiece } from './drag.js';
+import { DrawShape } from './draw.js';
+import { explosion } from './explosion.js';
+import * as cg from './types.js';
 
 export interface Api {
   // reconfigure the instance. Accepts all config options, except for viewOnly & drawable.visible.

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,7 +1,7 @@
-import { HeadlessState } from './state';
-import { pos2key, key2pos, opposite, distanceSq, allPos, computeSquareCenter } from './util';
-import { premove, queen, knight } from './premove';
-import * as cg from './types';
+import { HeadlessState } from './state.js';
+import { pos2key, key2pos, opposite, distanceSq, allPos, computeSquareCenter } from './util.js';
+import { premove, queen, knight } from './premove.js';
+import * as cg from './types.js';
 
 export function callUserFunction<T extends (...args: any[]) => void>(f: T | undefined, ...args: Parameters<T>): void {
   if (f) setTimeout(() => f(...args), 1);

--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -1,12 +1,12 @@
-import { Api, start } from './api';
-import { Config, configure } from './config';
-import { HeadlessState, State, defaults } from './state';
+import { Api, start } from './api.js';
+import { Config, configure } from './config.js';
+import { HeadlessState, State, defaults } from './state.js';
 
-import { renderWrap } from './wrap';
-import * as events from './events';
-import { render, renderResized, updateBounds } from './render';
-import * as svg from './svg';
-import * as util from './util';
+import { renderWrap } from './wrap.js';
+import * as events from './events.js';
+import { render, renderResized, updateBounds } from './render.js';
+import * as svg from './svg.js';
+import * as util from './util.js';
 
 export function Chessground(element: HTMLElement, config?: Config): Api {
   const maybeState: State | HeadlessState = defaults();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
-import { HeadlessState } from './state';
-import { setCheck, setSelected } from './board';
-import { read as fenRead } from './fen';
-import { DrawShape, DrawBrushes } from './draw';
-import * as cg from './types';
+import { HeadlessState } from './state.js';
+import { setCheck, setSelected } from './board.js';
+import { read as fenRead } from './fen.js';
+import { DrawShape, DrawBrushes } from './draw.js';
+import * as cg from './types.js';
 
 export interface Config {
   fen?: cg.FEN; // chess position in Forsyth notation

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -1,9 +1,9 @@
-import { State } from './state';
-import * as board from './board';
-import * as util from './util';
-import { clear as drawClear } from './draw';
-import * as cg from './types';
-import { anim } from './anim';
+import { State } from './state.js';
+import * as board from './board.js';
+import * as util from './util.js';
+import { clear as drawClear } from './draw.js';
+import * as cg from './types.js';
+import { anim } from './anim.js';
 
 export interface DragCurrent {
   orig: cg.Key; // orig key of dragging piece

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,7 +1,7 @@
-import { State } from './state';
-import { unselect, cancelMove, getKeyAtDomPos, getSnappedKeyAtDomPos, whitePov } from './board';
-import { eventPosition, isRightButton } from './util';
-import * as cg from './types';
+import { State } from './state.js';
+import { unselect, cancelMove, getKeyAtDomPos, getSnappedKeyAtDomPos, whitePov } from './board.js';
+import { eventPosition, isRightButton } from './util.js';
+import * as cg from './types.js';
 
 export interface DrawShape {
   orig: cg.Key;

--- a/src/drop.ts
+++ b/src/drop.ts
@@ -1,8 +1,8 @@
-import { State } from './state';
-import * as cg from './types';
-import * as board from './board';
-import * as util from './util';
-import { cancel as dragCancel } from './drag';
+import { State } from './state.js';
+import * as cg from './types.js';
+import * as board from './board.js';
+import * as util from './util.js';
+import { cancel as dragCancel } from './drag.js';
 
 export function setDropMode(s: State, piece?: cg.Piece): void {
   s.dropmode = {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,9 +1,9 @@
-import { State } from './state';
-import * as drag from './drag';
-import * as draw from './draw';
-import { drop } from './drop';
-import { isRightButton } from './util';
-import * as cg from './types';
+import { State } from './state.js';
+import * as drag from './drag.js';
+import * as draw from './draw.js';
+import { drop } from './drop.js';
+import { isRightButton } from './util.js';
+import * as cg from './types.js';
 
 type MouchBind = (e: cg.MouchEvent) => void;
 type StateMouchBind = (d: State, e: cg.MouchEvent) => void;

--- a/src/explosion.ts
+++ b/src/explosion.ts
@@ -1,5 +1,5 @@
-import { State } from './state';
-import { Key } from './types';
+import { State } from './state.js';
+import { Key } from './types.js';
 
 export function explosion(state: State, keys: Key[]): void {
   state.exploding = { stage: 1, keys };

--- a/src/fen.ts
+++ b/src/fen.ts
@@ -1,5 +1,5 @@
-import { pos2key, invRanks } from './util';
-import * as cg from './types';
+import { pos2key, invRanks } from './util.js';
+import * as cg from './types.js';
 
 export const initial: cg.FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { Chessground } from './chessground';
+import { Chessground } from './chessground.js';
 
 export default Chessground;

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -1,5 +1,5 @@
-import * as util from './util';
-import * as cg from './types';
+import * as util from './util.js';
+import * as cg from './types.js';
 
 type Mobility = (x1: number, y1: number, x2: number, y2: number) => boolean;
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,9 +1,9 @@
-import { State } from './state';
-import { key2pos, createEl, posToTranslate as posToTranslateFromBounds, translate } from './util';
-import { whitePov } from './board';
-import { AnimCurrent, AnimVectors, AnimVector, AnimFadings } from './anim';
-import { DragCurrent } from './drag';
-import * as cg from './types';
+import { State } from './state.js';
+import { key2pos, createEl, posToTranslate as posToTranslateFromBounds, translate } from './util.js';
+import { whitePov } from './board.js';
+import { AnimCurrent, AnimVectors, AnimVector, AnimFadings } from './anim.js';
+import { DragCurrent } from './drag.js';
+import * as cg from './types.js';
 
 type PieceName = string; // `$color $role`
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,9 +1,9 @@
-import * as fen from './fen';
-import { AnimCurrent } from './anim';
-import { DragCurrent } from './drag';
-import { Drawable } from './draw';
-import { timer } from './util';
-import * as cg from './types';
+import * as fen from './fen.js';
+import { AnimCurrent } from './anim.js';
+import { DragCurrent } from './drag.js';
+import { Drawable } from './draw.js';
+import { timer } from './util.js';
+import * as cg from './types.js';
 
 export interface HeadlessState {
   pieces: cg.Pieces;
@@ -13,7 +13,7 @@ export interface HeadlessState {
   lastMove?: cg.Key[]; // squares part of the last move ["c3"; "c4"]
   selected?: cg.Key; // square currently selected "a1"
   coordinates: boolean; // include coords attributes
-  ranksPosition: cg.RanksPosition // position ranks on either side. left | right
+  ranksPosition: cg.RanksPosition; // position ranks on either side. left | right
   autoCastle: boolean; // immediately complete the castle by moving the rook after king move
   viewOnly: boolean; // don't bind events: the user will never be able to move pieces around
   disableContextMenu: boolean; // because who needs a context menu on a chessboard

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1,7 +1,7 @@
-import { State } from './state';
-import { key2pos } from './util';
-import { Drawable, DrawShape, DrawShapePiece, DrawBrush, DrawBrushes, DrawModifiers } from './draw';
-import * as cg from './types';
+import { State } from './state.js';
+import { key2pos } from './util.js';
+import { Drawable, DrawShape, DrawShapePiece, DrawBrush, DrawBrushes, DrawModifiers } from './draw.js';
+import * as cg from './types.js';
 
 export function createElement(tagName: string): SVGElement {
   return document.createElementNS('http://www.w3.org/2000/svg', tagName);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import * as cg from './types';
+import * as cg from './types.js';
 
 export const invRanks: readonly cg.Rank[] = [...cg.ranks].reverse();
 

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,7 +1,7 @@
-import { HeadlessState } from './state';
-import { setVisible, createEl } from './util';
-import { colors, files, ranks, Elements } from './types';
-import { createElement as createSVG, setAttributes } from './svg';
+import { HeadlessState } from './state.js';
+import { setVisible, createEl } from './util.js';
+import { colors, files, ranks, Elements } from './types.js';
+import { createElement as createSVG, setAttributes } from './svg.js';
 
 export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
   // .cg-wrap (element passed to Chessground)


### PR DESCRIPTION
Adds .js extensions to all imports
Imports in es modules are supposed to include the file extension
the typescript team provides no way to automatically add extension
in the emmited code and recommends using the .js extension in the
src.